### PR TITLE
DESCRIPTIONファイルへ依存パッケージを記述

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,3 +10,9 @@ License: What license is it under?
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.1
+Imports: 
+    here,
+    sf,
+    utils
+Depends: 
+    tidyverse

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 ```{r}
-devtools::install_github("Ymgc19/simplecensus")
+# install.packages("pak")
+pak::pak("Ymgc19/simplecensus")
 ```


### PR DESCRIPTION
Rのバージョンを更新してみたところ、依存パッケージが読み込めなくなっていたため、下記コードにより依存パッケージをDESCRIPTIONファイルへ追加しました。

```
usethis::use_package("tidyverse", type = "Depends")
usethis::use_package("here")
usethis::use_package("sf")
usethis::use_package("utils")
```

また、READMEのインストール方法を`pak::pak`に変更しました。これで自動的に依存パッケージがインストールされます。